### PR TITLE
fix: label for result-service set to 'demo-voting-app'

### DIFF
--- a/cloud/all-in-one.yml
+++ b/cloud/all-in-one.yml
@@ -94,7 +94,7 @@ metadata:
   name: result-service
   labels:
     name: result-service
-    app: demo-result-app
+    app: demo-voting-app
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
@@ -160,7 +160,7 @@ spec:
     selector:
         matchLabels:
           name: voting-app-pod
-          app: demo-voting-app 
+          app: demo-voting-app
     template:
       metadata:
           name: voting-app-pod


### PR DESCRIPTION
исправлена метка для службы result-service на правильную:

```
  labels:
    name: result-service
    app: demo-voting-app
```